### PR TITLE
Added a GitHub action to automatically make PRs for new repositories.

### DIFF
--- a/.github/workflows/check-repos.yml
+++ b/.github/workflows/check-repos.yml
@@ -1,0 +1,32 @@
+name: Check for new Project Repos
+
+on:
+  push:
+    branches:
+      - main  
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  check-project-repos:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Update project repositories
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+        run: |
+          npm install -g meta
+          ./scripts/update.sh
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          commit-message: Added newly created repositories.
+          delete-branch: true
+          title: 'Added any newly created repositories.'
+          body: |
+            Added any missing repositories.
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,6 @@
 /opensearch-devops/
 /cross-cluster-replication/
 /opensearch-cli/
-/.github/
 /piped-processing-language/
 /OpenSearch/
 /alerting/

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -2,5 +2,13 @@
 
 for repo in `gh repo list -L 100 --public opensearch-project | cut -f1 | cut -d/ -f2 | sort -f` 
 do
+    if [ ! -d $repo ]; then
+        git clone --depth 1 https://github.com/opensearch-project/$repo.git
+    fi
+done
+
+for repo in `gh repo list -L 100 --public opensearch-project | cut -f1 | cut -d/ -f2 | sort -f` 
+do
+    echo ⌛ Checking $repo ...
     meta project import $repo git@github.com:opensearch-project/$repo.git
 done


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Adds a workflow that keeps the meta project up-to-date.

There's a bit of a hacky approach to pre-checkout repos under https://... in update.sh to avoid credentials issues for git@ access, but it actually makes that script work for both kinds of GitHub auth for everyone.

See https://github.com/dblock/project-meta/runs/3243947548?check_suite_focus=true for a successful pass and https://github.com/dblock/project-meta/pull/1 for a PR.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
