### PR TITLE
Remove unnecessary quotes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,13 +87,13 @@ meta exec "gh issue create --label backwards-compatibility --title 'Ensure backw
 Find all issues labeled `v1.0.0`.
 
 ```
-meta exec "gh issue list -l 'v1.0.0'"
+meta exec "gh issue list -l v1.0.0"
 ```
 
 How many are left?
 
 ```
-meta exec "gh issue list -l 'v1.0.0'" | wc -l
+meta exec "gh issue list -l v1.0.0" | wc -l
 ```
 
 ### Check Tags


### PR DESCRIPTION
Signed-off-by: dblock <dblock@dblock.org>

### Description
Seems like quotes make things not work on Windows.
  
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
