### PR TITLE
Rename trace-analytics to observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@
 /ml-commons/
 /opensearch-benchmark/
 /opensearch-benchmark-workloads/
+/observability/

--- a/.meta
+++ b/.meta
@@ -31,7 +31,7 @@
     "security": "git@github.com:opensearch-project/security.git",
     "security-dashboards-plugin": "git@github.com:opensearch-project/security-dashboards-plugin.git",
     "sql": "git@github.com:opensearch-project/sql.git",
-    "trace-analytics": "git@github.com:opensearch-project/trace-analytics.git",
+    "observability": "git@github.com:opensearch-project/observability.git",
     "opensearch-plugin-template-java": "git@github.com:opensearch-project/opensearch-plugin-template-java.git",
     "project-meta": "git@github.com:opensearch-project/project-meta.git",
     "geospatial": "git@github.com:opensearch-project/geospatial.git",


### PR DESCRIPTION
Signed-off-by: Joshua Li <joshuali925@gmail.com>

### Description
Trace-analytics repo is renamed to Observability, rename it here as well
 
### Issues Resolved
https://github.com/opensearch-project/observability/issues/336
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
