### PR TITLE
Using Github App for check-repos workflow

### DIFF
--- a/.github/workflows/check-repos.yml
+++ b/.github/workflows/check-repos.yml
@@ -11,22 +11,34 @@ jobs:
   check-project-repos:
     runs-on: ubuntu-latest
     steps:
+      - name: GitHub App token
+        id: github_app_token
+        uses: tibdex/github-app-token@v1.5.0
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
+          installation_id: 22958780
+
       - uses: actions/checkout@v2
       - name: Update project repositories
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}      
+          GITHUB_TOKEN: ${{ steps.github_app_token.outputs.token }}      
         run: |
           npm install -g meta
           ./scripts/update.sh
           echo REPOS_ADDED=$(git diff --unified=0 .gitignore | grep '+/' | cut -f2 -d'/' | paste -sd ',' - | sed "s/,/, /g" | sed 's/\(.*\),/\1 and/') >> $GITHUB_ENV
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
+          token: ${{ steps.github_app_token.outputs.token }}
           commit-message: Added ${{ env.REPOS_ADDED }}.
+          signoff: true
           delete-branch: true
           title: 'Added ${{ env.REPOS_ADDED }}.'
           body: |
             Added ${{ env.REPOS_ADDED }}.
+
       - name: Check outputs
         run: |
           echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"


### PR DESCRIPTION
Signed-off-by: Vacha Shah <vachshah@amazon.com>

### Description
Coming from https://github.com/opensearch-project/project-meta/pull/38#issuecomment-1055669522, using Github App to trigger CI workflows on generated PRs. Also adding an option for signoff on the auto-generated PR.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
