### PR TITLE
Updates roadmap maintainers policy

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -23,6 +23,10 @@ This document explains who the maintainers are (see below), what they do in this
 
 Maintainers are active and visible members of the community, and have [maintain-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and evolve code as follows.
 
+## OpenSearch Project Roadmap Responsibilities
+
+Maintainers have access to manage the [OpenSearch project roadmap](https://github.com/orgs/opensearch-project/projects/1) and are responsible for working with individual repo maintainers to ensure the roadmap is up to date with new planned features. They ensure a high quality bar for cards that a placed in the roadmap. They are not responsible for determining what features are built and prioritized.
+
 ### Uphold Code of Conduct
 
 Model the behavior set forward by the [Code of Conduct](CODE_OF_CONDUCT.md) and raise any violations to other maintainers and admins.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,7 @@
   - [Triage Open Issues](#triage-open-issues)
   - [Be Responsive](#be-responsive)
   - [Maintain Overall Health of the Repo](#maintain-overall-health-of-the-repo)
+  - [Maintain OpenSearch Project Roadmap](#maintain-opensearch-project-roadmap)
   - [Promote Other Maintainers](#promote-other-maintainers)
   
 ## Overview
@@ -22,10 +23,6 @@ This document explains who the maintainers are (see below), what they do in this
 ## Maintainer Responsibilities
 
 Maintainers are active and visible members of the community, and have [maintain-level permissions on a repository](https://docs.github.com/en/organizations/managing-access-to-your-organizations-repositories/repository-permission-levels-for-an-organization). Use those privileges to serve the community and evolve code as follows.
-
-## OpenSearch Project Roadmap Responsibilities
-
-Maintainers have access to manage the [OpenSearch project roadmap](https://github.com/orgs/opensearch-project/projects/1) and are responsible for working with individual repo maintainers to ensure the roadmap is up to date with new planned features. They ensure a high quality bar for cards that a placed in the roadmap. They are not responsible for determining what features are built and prioritized.
 
 ### Uphold Code of Conduct
 
@@ -56,6 +53,10 @@ Respond to enhancement requests, and forum posts. Allocate time to reviewing and
 ### Maintain Overall Health of the Repo
 
 Keep the `main` branch at production quality at all times. Backport features as needed. Cut release branches and tags to enable future patches. 
+
+### Maintain OpenSearch Project Roadmap
+
+Maintainers have access to manage the [OpenSearch project roadmap](https://github.com/orgs/opensearch-project/projects/1) and are responsible for working with individual repo maintainers to ensure the roadmap is up to date with new planned features. They ensure a high quality bar for cards that a placed in the roadmap. They are not responsible for determining what features are built and prioritized.
 
 ### Promote Other Maintainers
 


### PR DESCRIPTION
### Description
The information for someone to add a feature to the [OpenSearch Roadmap](https://github.com/orgs/opensearch-project/projects/1) is available on this [FAQ](https://opensearch.org/faq#q1.19) on the project website. It states “As the feature is developed, the maintainers of the repo will also work with you to incorporate it into the roadmap.” This is true for individual repos. However, the OpenSearch Roadmap managed on the opensearch-project GitHub organization is kept up to date by maintainers of the project-meta repo. This PR clarifies the responsibilities of the project-meta repo maintainers includes managing the OpenSearch GitHub organization roadmap.

This proposal is also related to this PR: https://github.com/opensearch-project/.github/pull/72
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
