### PR TITLE
[Policy & Guildelines] COMMUNICATIONS.md and Public Slack

### DIFF
--- a/COMMUNICATIONS.md
+++ b/COMMUNICATIONS.md
@@ -1,0 +1,94 @@
+# OpenSearch Project Communication 
+
+- [Overview](#overview)
+- [Public Slack](#public-slack)
+  - [Getting Started](#getting-started)
+  - [Workspace Channels](#workspace-channels)
+  - [Tips](#tips)
+
+## Overview
+
+The purpose of this document is to provide references and information regarding
+the communication channels for the OpenSearch Project. All communication is
+subject to the [OpenSearch Code of Conduct](CODE_OF_CONDUCT.md). Please see
+[CONTRIBUTING](CONTRIBUTING.md) if you're interested in contributing to the
+project.
+
+## Public Slack
+
+OpenSearch has a workspace on [Slack](https://opensearch.slack.com) to provide
+public communication channels for all people interested in OpenSearch.
+
+The following guidelines include a Getting Started for steps to register and
+setup the workspace along with tips for using the workspace. Please read through
+these guidelines carefully and thoroughly. All communications and behavior on
+the public slack workspace is subject to the 
+[OpenSearch Code of Conduct](CODE_OF_CONDUCT.md).
+
+### Getting Started
+
+_Join Us_
+
+  * Register your account at https://opensearch.slack.com. You will be required
+    to enroll in two-factor authentication to ensure the best possible security
+    of your account.
+
+_Update Profile_
+
+  * Add your interests or keywords in the “What I do” section of your profile 
+    along with your Title and Company/Organization. This is how participants 
+    can network and connect with each other by common interests. No anonymous 
+    display names are allowed.
+  * Feel free to update your profile photo to something unique to you. All 
+    profile photos are subject to the 
+    [OpenSearch Code of Conduct](CODE_OF_CONDUCT.md) policies.
+  * Optionally share your pronouns by adding them to the end of your Full Name 
+    in your profile. This way other participants will be able to see them and 
+    be respectful to your communication preferences. Please also be respectful 
+    of other participants’ pronouns.
+
+### Workspace Channels
+
+After you join OpenSearch workspace you will be automatically added to the 
+following channels:
+
+  * **#general** - a channel for asking general questions. Based on the question 
+    or discussion users will mostly likely be directed to more specific 
+    channels based on the topics of interest.
+  * **#random** - consider this the water cooler in a face to face workspace. 
+    Feel free to introduce yourself to the community, share what you’re 
+    working on, or what you’re excited about learning with OpenSearch.
+
+There are dedicated channels for the following (note that participants might 
+be directed to more specific channels based on the nature of the discussion):
+
+  * **#dev** - primary channel for development questions. This is a good place to 
+    start for participants interested in OpenSearch development but are not 
+    sure which channels to join.  
+  * **#core** -  primary channel for core OpenSearch. General questions and 
+    discussions about the core can be asked here. 
+  * **#dashboards** - primary channel for Dashboards. General questions and 
+    discussions about dashboards can be asked here. 
+  * **#infra** - primary channel for infra. General discussions, questions, or infra 
+    requests can be posted here.
+  * **#{project}-build** - dedicated channels where build bots will post failing CI/CD 
+    builds for test failure triage and bug fixes.
+  * **#maintainers** - a private maintainers channel to discuss new maintainers, and 
+    project sensitive topics.
+
+### Tips
+
+  * Try to keep communications in the open - Where possible, try to have 
+    conversations in asynchronous formats like GitHub issues, PRs, and discussion 
+    forums. 
+  * Use the [OpenSearch Discussion Forum](https://forum.opensearch.org) for 
+    technical support discussions or, at least, open a summary discussion on the 
+    forum so useful findings can be shared with the rest of the community. 
+  * Keep discussions organized - use threads to respond to comments inline instead 
+    of posting to the entire channel.
+  * Expect asynchronous response time - do not assume immediate response time as 
+    participants are likely in different time zones.
+  * Protecting IP and legally protected information is your responsibility, this is 
+    a public forum. Don’t presume anything said here will remain private.
+  * **DO NOT** post CVEs or Security issues publicly. See [SECURITY](SECURITY.md)
+    for guidelines on handling security issues.


### PR DESCRIPTION
Adds new COMMUNICATIONS.md file describing the OpenSearch Project communications
policy and guidelines. First commit includes policy and guidelines for upcoming
public slack channel.

closes https://github.com/opensearch-project/.github/issues/63