### PR TITLE
Fix: gh command line uses a newer syntax, visibility=public.

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-for repo in `gh repo list -L 100 --public opensearch-project | cut -f1 | cut -d/ -f2 | sort -f` 
+for repo in `gh repo list -L 100 --visibility=public opensearch-project | cut -f1 | cut -d/ -f2 | sort -f` 
 do
     if [ ! -d $repo ]; then
         git clone --depth 1 https://github.com/opensearch-project/$repo.git
     fi
 done
 
-for repo in `gh repo list -L 100 --public opensearch-project | cut -f1 | cut -d/ -f2 | sort -f` 
+for repo in `gh repo list -L 100 --visibility=public opensearch-project | cut -f1 | cut -d/ -f2 | sort -f` 
 do
     echo ⌛ Checking $repo ...
     meta project import $repo git@github.com:opensearch-project/$repo.git


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Looking at https://github.com/opensearch-project/project-meta/pull/47 the newer version of the default GH client installed on the workers by default is now 2.0, and wants `--visibility=public`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
