### PR TITLE
Replace `cut` with JSON parsing

### DIFF
--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-for repo in `gh repo list -L 100 --visibility=public opensearch-project | cut -f1 | cut -d/ -f2 | sort -f` 
+for repo in `gh repo list -L 100 --visibility=public opensearch-project --json name --jq '.[].name' | sort -f`
 do
     if [ ! -d $repo ]; then
         git clone --depth 1 https://github.com/opensearch-project/$repo.git
     fi
 done
 
-for repo in `gh repo list -L 100 --visibility=public opensearch-project | cut -f1 | cut -d/ -f2 | sort -f` 
+for repo in `gh repo list -L 100 --visibility=public opensearch-project --json name --jq '.[].name' | sort -f`
 do
     echo ⌛ Checking $repo ...
     meta project import $repo git@github.com:opensearch-project/$repo.git


### PR DESCRIPTION
Using JSON parsing built in to the github CLI should be more clear and
less fragile than parsing the raw text output.

Signed-off-by: Andrew Ross <andrross@amazon.com>