### PR TITLE
Updated MAINTAINERS.

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+@andrross
+@dblock
+@peternied
+@dblock

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,6 +4,9 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer               | GitHub ID                           | Affiliation |
-| ------------------------ | ----------------------------------- | ----------- |
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock) | Amazon      |
+| Maintainer               | GitHub ID                                 | Affiliation |
+| ------------------------ | ----------------------------------------- | ----------- |
+| Andrew Ross              | [andrross](https://github.com/andrross)   | Amazon      |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)       | Amazon      |
+| Peter Nied               | [peternied](https://github.com/peternied) | Amazon      |
+| Vacha Shah               | [dblock](https://github.com/dblock)       | Amazon      |


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Baseline maintainers.

### Issues Resolved

Coming from https://github.com/opensearch-project/.github/issues/125. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
