### PR TITLE
Add dispatch trigger to allow manual trigger by maintainers

### DIFF
--- a/.github/workflows/check-repos.yml
+++ b/.github/workflows/check-repos.yml
@@ -6,6 +6,7 @@ on:
       - main  
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
 
 jobs:
   check-project-repos:


### PR DESCRIPTION
### Description
Add dispatch trigger to allow manual trigger by maintainers

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
