### PR TITLE
Updated affiliation for @dblock.

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,6 +7,6 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Maintainer               | GitHub ID                                 | Affiliation |
 | ------------------------ | ----------------------------------------- | ----------- |
 | Andrew Ross              | [andrross](https://github.com/andrross)   | Amazon      |
-| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)       | Amazon      |
+| Daniel "dB." Doubrovkine | [dblock](https://github.com/dblock)       | Independent |
 | Peter Nied               | [peternied](https://github.com/peternied) | Amazon      |
 | Vacha Shah               | [VachaShah](https://github.com/VachaShah) | Amazon      |


### PR DESCRIPTION
### Description

Updated affiliation for @dblock.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
